### PR TITLE
Introduce new attributes to enable the use behind a proxy

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,10 +114,12 @@ class flapjack(
   $prd_web_ui_logger_syslog_errors = true,
   $prd_web_ui_port                 = '3080',
   $prd_web_ui_timeout              = '300',
+  $prd_web_ui_base_url             = undef,
 
   ## JSON API Params
   $prd_json_api_access_log           = 'jsonapi_access.log',
   $prd_json_api_base_url             = 'http://localhost',
+  $prd_json_api_url                  = undef,
   $prd_json_api_logger_level         = 'INFO',
   $prd_json_api_logger_syslog_errors = true,
   $prd_json_api_port                 = '3081',

--- a/templates/etc/flapjack/flapjack_config.erb
+++ b/templates/etc/flapjack/flapjack_config.erb
@@ -283,7 +283,14 @@ production:
       port: <%=@prd_web_ui_port%>
       timeout: <%=@prd_web_ui_timeout%>
       access_log: '<%=@prd_log_dir-%><%=@prd_web_ui_accesslog-%>'
+<% if @prd_web_ui_base_url -%>
+      base_url: '<%=@prd_web_ui_base_url-%>'
+<% end -%>
+<% if @prd_json_api_url -%>
+      api_url: '<%=@prd_json_api_url-%>'
+<% else -%>
       api_url: '<%=@prd_json_api_base_url-%>:<%=@prd_json_api_port-%>/'
+<% end -%>
       # Full path to location of logo file, e.g. /etc/flapjack/custom_logo.png
       #logo_image_path: "/etc/flapjack/web/custom_logo/flapjack-2013-notext-transparent-300-300.png"
       logger:
@@ -295,7 +302,11 @@ production:
       port: <%=@prd_json_api_port%>
       timeout: <%=@prd_json_api_timeout%>
       access_log: '<%=@prd_log_dir-%><%=@prd_json_api_access_log%>'
+<% if @prd_json_api_url -%>
+      base_url: '<%=@prd_json_api_url-%>'
+<% else -%>
       base_url: '<%=@prd_json_api_base_url-%>:<%=@prd_json_api_port-%>/'
+<% end -%>
       logger:
         level: <%=@prd_json_api_logger_level%>
         syslog_errors: <%=prd_jsonapi_syslog%>


### PR DESCRIPTION
- prd_web_ui_base_url  : The public URL for flapjack
- prd_json_api_url : The public URL for the flapjack-api

This enables us to run flapjack on https://servername/flapjack/ with the following config:
### flapjack

  prd_json_api_url => 'https://monitoring/flapjack/api/',
  prd_web_ui_base_url => 'https://monitoring/flapjack/',
### apache

  ProxyHTMLURLMap http://127.0.0.1:3080/ /flapjack/
  ProxyHTMLExtended On
  ProxyPass /flapjack/api/ http://127.0.0.1:3081/
  ProxyPassReverse /flapjack/api/ http://127.0.0.1:3081/
  ProxyPass /flapjack/ http://127.0.0.1:3080/
  ProxyPassReverse /flapjack/ http://127.0.0.1:3080/
